### PR TITLE
Add yarn berry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 **[⚖️ &nbsp;Options](#options)** | **[🤼‍♀️ &nbsp;Codependencies](#codependencies-arraystring--recordstring-string)** | **[👌&nbsp;Codependencies Array](#array-types)**
 
-**[🖼 &nbsp;Demos](#demos)** | **[🤝 &nbsp;Contributing](#contributing)** | **[🗺 &nbsp;Roadmap](#roadmap)**
+**[🖼 &nbsp;Demos](#demos)** | **[🐛 &nbsp;Debugging](#debugging)** | **[🤝 &nbsp;Contributing](#contributing)** | **[🗺 &nbsp;Roadmap](#roadmap)**
 
 ---
 
@@ -242,12 +242,35 @@ An **optional** string containing a package to file which contains `codependence
 An **optional** string containing a search path for location config files.
 - The default value is `undefined`
 
+### `yarnConfig`: `boolean`
+
+An **optional** boolean value used to enable \***yarn config** checking
+- The default value is `false`
+
 ---
 
 ## Demos
 
 - **[Codependence Cron](https://github.com/yowainwright/codependence-cron):** Codependence running off a Github Action cron job.
 - **[Codependence Monorepo](https://github.com/yowainwright/codependence-monorepo):** Codependence monorepo example.
+
+---
+
+## Debugging
+
+### `private packages`
+
+If there is a `.npmrc` file, there is no issue with **Codependence** monitoring private packages. However, if a yarn config is used, Codependence must be instructed to run `version` checks differently.
+
+---
+
+##### Fixes
+
+- With the CLI, add the `--yarnConfig` option.
+- With node, add `yarnConfig: true` to your options or your config.
+- For other private package issues, submit an [issue](https://github.com/yowainwright/codependence/issues) or [pull request](https://github.com/yowainwright/codependence/pulls).
+
+
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tsup": "^6.1.0",
     "tsutils": "^3.21.0",
     "typescript": "^4.7.3",
-    "vitest": "^0.15.0"
+    "vitest": "^0.16.0"
   },
   "keywords": [
     "peerDependencies",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ specifiers:
   tsup: ^6.1.0
   tsutils: ^3.21.0
   typescript: ^4.7.3
-  vitest: ^0.15.0
+  vitest: ^0.16.0
 
 dependencies:
   commander: 9.3.0
@@ -62,7 +62,7 @@ devDependencies:
   tsup: 6.1.0_3u6mezahkkqoy6xqszupxyezbi
   tsutils: 3.21.0_typescript@4.7.3
   typescript: 4.7.3
-  vitest: 0.15.0_c8@7.11.3
+  vitest: 0.16.0_c8@7.11.3
 
 packages:
 
@@ -4495,13 +4495,13 @@ packages:
       tinycolor2: 1.4.2
     dev: false
 
-  /tinypool/0.1.3:
-    resolution: {integrity: sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==}
+  /tinypool/0.2.1:
+    resolution: {integrity: sha512-HFU5ZYVq3wBfhSaf8qdqGsneaqXm0FgJQpoUlJbVdHpRLzm77IneKAD3RjzJWZvIv0YpPB9S7LUW53f6BE6ZSg==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy/0.3.2:
-    resolution: {integrity: sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==}
+  /tinyspy/0.3.3:
+    resolution: {integrity: sha512-gRiUR8fuhUf0W9lzojPf1N1euJYA30ISebSfgca8z76FOvXtVXqd5ojEIaKLWbDQhAaC3ibxZIjqbyi4ybjcTw==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -4822,8 +4822,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.15.0_c8@7.11.3:
-    resolution: {integrity: sha512-ofXZ8tBYAkVJpTpkaGruBh9nG6lO9cs04IdFpneDblCwBpncnlpEgZvlF3XWF4lSsklPe9le4MO8+j90DnsX+g==}
+  /vitest/0.16.0_c8@7.11.3:
+    resolution: {integrity: sha512-Ntp6jrM8wf2NMtamMBLkRBBdeqHkgAH/WMh5Xryts1j2ft2D8QZQbiSVFkSl4WmEQzcPP0YM069g/Ga1vtnEtg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -4848,8 +4848,8 @@ packages:
       chai: 4.3.6
       debug: 4.3.4
       local-pkg: 0.4.1
-      tinypool: 0.1.3
-      tinyspy: 0.3.2
+      tinypool: 0.2.1
+      tinyspy: 0.3.3
       vite: 2.9.12
     transitivePeerDependencies:
       - less

--- a/src/program.ts
+++ b/src/program.ts
@@ -68,6 +68,7 @@ program
   .option("-cds, --codependencies [codependencies...]", "deps to check")
   .option("-c, --config <config>", "path to a config file")
   .option("-s, --searchPath <searchPath>", "path to do a config file search")
+  .option("-y, --yarnConfig", "enable yarn config support")
   .action(action)
   .parse(process.argv);
 

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -119,7 +119,7 @@ export const constructVersionMap = async (
           `🤼‍♀️ => Is ☝️ a private package? Does that name look correct? 🧐`
         );
         console.error(
-          `🤼‍♀️ => Read more about configuring dependencies here: https://github.com/yowainwright/codependence#options`
+          `🤼‍♀️ => Read more about configuring dependencies here: https://github.com/yowainwright/codependence#debugging`
         );
         process.exit(1);
       }

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -85,6 +85,7 @@ export const constructVersionMap = async ({
           item.length > 1 &&
           !item.includes(" ")
         ) {
+          // the following 2 lines capture only accepted npm package names
           const isModuleSafeCharacters = /[A-Za-z0-9\-_.]/.test(item);
           if (!isModuleSafeCharacters) throw "invalid item";
           const cmd = !yarnConfig
@@ -446,7 +447,6 @@ export const checkFiles = async ({
       yarnConfig,
       isTesting,
     });
-    console.log({ versionMap });
     checkMatches({
       versionMap,
       rootDir,

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -71,7 +71,8 @@ export const logger = ({
 export const constructVersionMap = async (
   codependencies: CodeDependencies,
   exec = execPromise,
-  isDebugging = false
+  isDebugging = false,
+  yarnConfig = false
 ) => {
   const updatedCodeDependencies = await Promise.all(
     codependencies.map(async (item) => {
@@ -85,10 +86,17 @@ export const constructVersionMap = async (
         ) {
           const isModuleSafeCharacters = /[A-Za-z0-9\-_.]/.test(item);
           if (!isModuleSafeCharacters) throw "invalid item";
-          const { stdout = "" } = (await exec(
-            `npm view ${item} version latest`
-          )) as unknown as Record<string, string>;
-          const version = stdout.toString().replace("\n", "");
+          const cmd = !yarnConfig
+            ? `npm view ${item} version latest`
+            : `yarn npm info ${item} --fields version --json`;
+          const { stdout = "" } = (await exec(cmd)) as unknown as Record<
+            string,
+            string
+          >;
+
+          const version = !yarnConfig
+            ? stdout.toString().replace("\n", "")
+            : JSON.parse(stdout.toString().replace("\n", ""))?.version;
           if (version) return { [item]: version };
           throw `${version}`;
         } else {
@@ -102,7 +110,18 @@ export const constructVersionMap = async (
             message: (err as string).toString(),
             isDebugging,
           });
-        return {};
+        logger({
+          type: "error",
+          section: `constructVersionMap`,
+          message: `there was an error retrieving ${item}`,
+        });
+        console.error(
+          `🤼‍♀️ => Is ☝️ a private package? Does that name look correct? 🧐`
+        );
+        console.error(
+          `🤼‍♀️ => Read more about configuring dependencies here: https://github.com/yowainwright/codependence#options`
+        );
+        process.exit(1);
       }
     })
   );
@@ -412,6 +431,7 @@ export const checkFiles = async ({
   debug = false,
   silent = false,
   isCLI = false,
+  yarnConfig = false,
   isTesting = false,
 }: CheckFiles): Promise<void> => {
   try {
@@ -420,7 +440,8 @@ export const checkFiles = async ({
     const versionMap = await constructVersionMap(
       codependencies,
       execPromise,
-      debug
+      debug,
+      yarnConfig
     );
     checkMatches({
       versionMap,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type Options = {
   debug?: boolean;
   silent?: boolean;
   searchPath?: string;
+  yarnConfig?: boolean;
 };
 
 export type ConfigResult = { config: Options } & CosmiconfigResult;
@@ -30,6 +31,7 @@ export type CheckFiles = {
   silent?: boolean;
   isCLI?: boolean;
   isTesting?: boolean;
+  yarnConfig?: boolean;
 };
 
 export type CheckDependenciesForVersionOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,3 +82,11 @@ export type LoggerParams = {
   isDebugging?: boolean;
   obj?: any;
 };
+
+export type ConstructVersionMapOptions = {
+  codependencies: CodeDependencies;
+  exec?: any;
+  debug?: boolean;
+  yarnConfig?: boolean;
+  isTesting?: boolean;
+};

--- a/test/scripts.test.ts
+++ b/test/scripts.test.ts
@@ -1,4 +1,3 @@
-import { version } from "os";
 import { expect, test, vi } from "vitest";
 import * as scripts from "../src/scripts";
 const {
@@ -33,7 +32,10 @@ test("constructVersionMap => pass", async () => {
     stdout: "4.0.0",
     stderr: "",
   })) as any;
-  const result = await constructVersionMap(["lodash"], exec);
+  const result = await constructVersionMap({
+    codependencies: ["lodash"],
+    exec,
+  });
   expect(result).toEqual({ lodash: "4.0.0" });
 });
 
@@ -42,16 +44,11 @@ test("constructVersionMap => fail", async () => {
     stdout: "",
     stderr: "",
   })) as any;
-  const result = await constructVersionMap(["lodash"], exec);
-  expect(result).toEqual({});
-});
-
-test("constructVersionMap => fail", async () => {
-  const exec = vi.fn(() => ({
-    stdout: "",
-    stderr: "",
-  })) as any;
-  const result = await constructVersionMap(["lodash"], exec);
+  const result = await constructVersionMap({
+    codependencies: ["lodash"],
+    exec,
+    isTesting: true,
+  });
   expect(result).toEqual({});
 });
 


### PR DESCRIPTION
## Fixes

- Now supports checking private packages with no `.npmrc` file 
   - Currently only supports yarn configs (Are there others?) 

## Proposed Changes

- Adds `yarnConfig` options

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
