### PR TITLE
fix: fixes miss-matched dep in gh deploy action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,6 @@ jobs:
       - run: pnpm build
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v5
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           folder: page/app/dist


### PR DESCRIPTION
## Fixes

- Fixes a miss-matched version in the Github deployed action

---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
