### PR TITLE
fix: changing glob ignore default pattern

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -434,7 +434,7 @@ export const checkFiles = async ({
   codependencies,
   files: matchers = ['package.json'],
   rootDir = './',
-  ignore = ['node_modules/**/*', '**/node_modules/**/*'],
+  ignore = ['**/node_modules/**'],
   update = false,
   debug = false,
   silent = false,


### PR DESCRIPTION
## Fixes

- heap overflow on large monorepositories

## Proposed Changes

- default ignore pattern for the glob call

---

We noticed script failing(heap overflow) when used in large monorepositories. Changing glob ignore pattern fixes the issue.


