### PR TITLE
chore(release): v1.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codependence",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Enforce dependency version policy across projects, workspaces, and CI.",
   "homepage": "https://jeffry.in/codependence",
   "bugs": {

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://unpkg.com/codependence/src/config/schema.json",
-  "x-revision": "1.0.13",
+  "x-revision": "1.0.14",
   "x-created": "2025-11-23",
-  "x-updated": "2026-08-27",
+  "x-updated": "2026-08-28",
   "x-history": "https://github.com/yowainwright/codependence/commits/main/src/config/schema.json",
   "title": "Codependence Configuration",
   "description": "Configuration for managing dependency versions across your project",


### PR DESCRIPTION
Release v1.0.14.

This PR was created by `nub run release`.
GitHub auto-merges this PR after checks and reviews pass.
The release command then pushes the version tag.